### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Formats and parses ISO 8601 dates.
 
 Add it to your `rebar.config` deps:
 
-    {'iso8601',    ".*",    {git, "git@github.com:seansawyer/erlang_iso8601.git", {tag, "1.1.1"}}}
+    {'iso8601', ".*", {git, "git@github.com:seansawyer/erlang_iso8601.git", {tag, "1.1.1"}}}
+
+Or for `rebar3`:
+
+    {'iso8601', ".*", {git, "git://github.com/seansawyer/erlang_iso8601.git", {tag, "1.1.1"}}}
 
 Format a timestamp or calendar datetime tuple:
 


### PR DESCRIPTION
rebar3 doesn't like the old url notation; an explanatory line is suggested